### PR TITLE
수표 NBT 관련 버그 수정

### DIFF
--- a/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
+++ b/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
@@ -66,13 +66,13 @@ public class DLCEvent implements Listener {
             ItemStack item = e.getItem();
             if(e.getItem().getItemMeta() == null) return;
             if(NBT.hasTagKey(e.getItem(), "CASH")) {
-                double cash = Double.parseDouble(NBT.getStringTag(e.getItem(), "CASH").replace('"', ' ').trim());
+                double cash = NBT.getDoubleTag(e.getItem(), "CASH");
                 CashFunction.addCash(p, cash);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + cash + "§a캐시를 획득했습니다.");
             }
             else if(NBT.hasTagKey(e.getItem(), "MILEAGE")) {
-                double mileage = Double.parseDouble(NBT.getStringTag(e.getItem(), "MILEAGE").replace('"', ' ').trim());
+                double mileage = NBT.getDoubleTag(e.getItem(), "MILEAGE");
                 CashFunction.addMileage(p, mileage);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + mileage + "§a마일리지를 획득했습니다.");

--- a/v1_13_2/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
+++ b/v1_13_2/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
@@ -66,13 +66,13 @@ public class DLCEvent implements Listener {
             ItemStack item = e.getItem();
             if(e.getItem().getItemMeta() == null) return;
             if(NBT.hasTagKey(e.getItem(), "CASH")) {
-                double cash = Double.parseDouble(NBT.getStringTag(e.getItem(), "CASH").replace('"', ' ').trim());
+                double cash = NBT.getDoubleTag(e.getItem(), "CASH");
                 CashFunction.addCash(p, cash);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + cash + "§a캐시를 획득했습니다.");
             }
             else if(NBT.hasTagKey(e.getItem(), "MILEAGE")) {
-                double mileage = Double.parseDouble(NBT.getStringTag(e.getItem(), "MILEAGE").replace('"', ' ').trim());
+                double mileage = NBT.getDoubleTag(e.getItem(), "MILEAGE");
                 CashFunction.addMileage(p, mileage);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + mileage + "§a마일리지를 획득했습니다.");

--- a/v1_14_4/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
+++ b/v1_14_4/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
@@ -66,13 +66,13 @@ public class DLCEvent implements Listener {
             ItemStack item = e.getItem();
             if(e.getItem().getItemMeta() == null) return;
             if(NBT.hasTagKey(e.getItem(), "CASH")) {
-                double cash = Double.parseDouble(NBT.getStringTag(e.getItem(), "CASH").replace('"', ' ').trim());
+                double cash = NBT.getDoubleTag(e.getItem(), "CASH");
                 CashFunction.addCash(p, cash);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + cash + "§a캐시를 획득했습니다.");
             }
             else if(NBT.hasTagKey(e.getItem(), "MILEAGE")) {
-                double mileage = Double.parseDouble(NBT.getStringTag(e.getItem(), "MILEAGE").replace('"', ' ').trim());
+                double mileage = NBT.getDoubleTag(e.getItem(), "MILEAGE");
                 CashFunction.addMileage(p, mileage);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + mileage + "§a마일리지를 획득했습니다.");

--- a/v1_15_2/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
+++ b/v1_15_2/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
@@ -66,13 +66,13 @@ public class DLCEvent implements Listener {
             ItemStack item = e.getItem();
             if(e.getItem().getItemMeta() == null) return;
             if(NBT.hasTagKey(e.getItem(), "CASH")) {
-                double cash = Double.parseDouble(NBT.getStringTag(e.getItem(), "CASH").replace('"', ' ').trim());
+                double cash = NBT.getDoubleTag(e.getItem(), "CASH");
                 CashFunction.addCash(p, cash);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + cash + "§a캐시를 획득했습니다.");
             }
             else if(NBT.hasTagKey(e.getItem(), "MILEAGE")) {
-                double mileage = Double.parseDouble(NBT.getStringTag(e.getItem(), "MILEAGE").replace('"', ' ').trim());
+                double mileage = NBT.getDoubleTag(e.getItem(), "MILEAGE");
                 CashFunction.addMileage(p, mileage);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + mileage + "§a마일리지를 획득했습니다.");

--- a/v1_16_5/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
+++ b/v1_16_5/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
@@ -66,13 +66,13 @@ public class DLCEvent implements Listener {
             ItemStack item = e.getItem();
             if(e.getItem().getItemMeta() == null) return;
             if(NBT.hasTagKey(e.getItem(), "CASH")) {
-                double cash = Double.parseDouble(NBT.getStringTag(e.getItem(), "CASH").replace('"', ' ').trim());
+                double cash = NBT.getDoubleTag(e.getItem(), "CASH");
                 CashFunction.addCash(p, cash);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + cash + "§a캐시를 획득했습니다.");
             }
             else if(NBT.hasTagKey(e.getItem(), "MILEAGE")) {
-                double mileage = Double.parseDouble(NBT.getStringTag(e.getItem(), "MILEAGE").replace('"', ' ').trim());
+                double mileage = NBT.getDoubleTag(e.getItem(), "MILEAGE");
                 CashFunction.addMileage(p, mileage);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + mileage + "§a마일리지를 획득했습니다.");

--- a/v1_17_1/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
+++ b/v1_17_1/src/main/java/com/darksoldier1404/dlc/events/DLCEvent.java
@@ -66,13 +66,13 @@ public class DLCEvent implements Listener {
             ItemStack item = e.getItem();
             if(e.getItem().getItemMeta() == null) return;
             if(NBT.hasTagKey(e.getItem(), "CASH")) {
-                double cash = Double.parseDouble(NBT.getStringTag(e.getItem(), "CASH").replace('"', ' ').trim());
+                double cash = NBT.getDoubleTag(e.getItem(), "CASH");
                 CashFunction.addCash(p, cash);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + cash + "§a캐시를 획득했습니다.");
             }
             else if(NBT.hasTagKey(e.getItem(), "MILEAGE")) {
-                double mileage = Double.parseDouble(NBT.getStringTag(e.getItem(), "MILEAGE").replace('"', ' ').trim());
+                double mileage = NBT.getDoubleTag(e.getItem(), "MILEAGE");
                 CashFunction.addMileage(p, mileage);
                 item.setAmount(item.getAmount() - 1);
                 p.sendMessage(plugin.prefix + "§e" + mileage + "§a마일리지를 획득했습니다.");


### PR DESCRIPTION
NBT는 같은 자료형끼리만 값을 불러올 수 있다.

수표에 값을 저장할때는 Double로 저장하고
불러올때는 String으로 불러오려고 하여 값이 불러와지지 않았다.